### PR TITLE
Fix Exception when HTTP error has non-JSON parsed body

### DIFF
--- a/lib/ridley/errors.rb
+++ b/lib/ridley/errors.rb
@@ -47,7 +47,7 @@ module Ridley
 
       def initialize(env)
         @env = env
-        @errors = Array(env[:body][:error]) || []
+        @errors = env[:body].is_a?(Hash) ? Array(env[:body][:error]) : []
 
         if errors.empty?
           @message = env[:body] || "no content body"

--- a/spec/unit/ridley/errors_spec.rb
+++ b/spec/unit/ridley/errors_spec.rb
@@ -30,5 +30,13 @@ describe Ridley::Errors do
         end
       end
     end
+
+    context "with an HTML error payload" do
+      subject { Ridley::Errors::HTTPError.new(:body => "<html><body><h1>Redirected</h1></body></html>") }
+
+      it "has an HTML body" do
+        subject.message.should eq("<html><body><h1>Redirected</h1></body></html>")
+      end
+    end
   end
 end


### PR DESCRIPTION
When Chef (or the HTTP server in front of it) returns an error that's in HTML, Ridley throws 

```
TypeError:
   can't convert Symbol into Integer
 # ./lib/ridley/errors.rb:50:in `[]'
 # ./lib/ridley/errors.rb:50:in `initialize'
 # ./spec/unit/ridley/errors_spec.rb:35:in `new'
 # ./spec/unit/ridley/errors_spec.rb:35:in `block (4 levels) in <top (required)>'
 # ./spec/unit/ridley/errors_spec.rb:38:in `block (4 levels) in <top (required)>'
```

This fixes the case where we don't have JSON in the error body.
