### PR TITLE
Do not decrypt a data bag item's id.

### DIFF
--- a/lib/ridley/resources/data_bag_item.rb
+++ b/lib/ridley/resources/data_bag_item.rb
@@ -168,7 +168,7 @@ module Ridley
     #
     # @return [Hash] decrypted attributes
     def decrypt
-      decrypted_hash = Hash[attributes.map { |key, value| [key, decrypt_value(value)] }]
+      decrypted_hash = Hash[attributes.map { |key, value| [key, key == "id" ? value : decrypt_value(value)] }]
       self.attributes = HashWithIndifferentAccess.new(decrypted_hash)
     end
 

--- a/spec/unit/ridley/resources/data_bag_item_spec.rb
+++ b/spec/unit/ridley/resources/data_bag_item_spec.rb
@@ -41,13 +41,22 @@ describe Ridley::DataBagItem do
   end
 
   describe "#decrypt" do
-    it "decrypts an encrypted item" do
+    before(:each) do
       encrypted_data_bag_secret = File.read(fixtures_path.join("encrypted_data_bag_secret").to_s)
       connection.stub(:encrypted_data_bag_secret).and_return(encrypted_data_bag_secret)
+    end
 
+    it "decrypts an encrypted value" do
       subject.attributes[:test] = "Xk0E8lV9r4BhZzcg4wal0X4w9ZexN3azxMjZ9r1MCZc="
       subject.decrypt
       subject.attributes[:test][:database][:username].should == "test"
+    end
+
+    it "does not decrypt the id field" do
+      id = "dbi_id"
+      subject.attributes[:id] = id
+      subject.decrypt
+      subject.attributes[:id].should == id
     end
   end
 end


### PR DESCRIPTION
`id` fields are not encrypted, so we don't need to decrypt it.
