### PR TITLE
Define constant with array of connection options

### DIFF
--- a/lib/ridley/connection.rb
+++ b/lib/ridley/connection.rb
@@ -72,6 +72,18 @@ module Ridley
 
     def_delegator :conn, :in_parallel
 
+    OPTIONS = [
+      :server_url,
+      :client_name,
+      :client_key,
+      :organization,
+      :validator_client,
+      :validator_path,
+      :encrypted_data_bag_secret_path,
+      :thread_count,
+      :ssl
+    ].freeze
+
     REQUIRED_OPTIONS = [
       :server_url,
       :client_name,

--- a/spec/unit/ridley/connection_spec.rb
+++ b/spec/unit/ridley/connection_spec.rb
@@ -17,6 +17,10 @@ describe Ridley::Connection do
     }
   end
 
+  it "exposes its options publicly" do
+    described_class::OPTIONS.should be_a Array
+  end
+
   describe "ClassMethods" do
     subject { Ridley::Connection }
 


### PR DESCRIPTION
Allows client to do Ridley::Connection.new(options.slice(*Ridley::Connection::OPTIONS))
