### PR TITLE
Capture exception on put and return to caller

### DIFF
--- a/lib/ridley/connection.rb
+++ b/lib/ridley/connection.rb
@@ -84,6 +84,14 @@ module Ridley
       self.url_prefix.to_s
     end
 
+    def put(*args)
+      begin
+        super
+      rescue Ridley::Errors::RidleyError => exception
+        exception
+      end
+    end
+
     # Stream the response body of a remote URL to a file on the local file system
     #
     # @param [String] target

--- a/lib/ridley/resources/cookbook_resource.rb
+++ b/lib/ridley/resources/cookbook_resource.rb
@@ -59,7 +59,9 @@ module Ridley
         url = "cookbooks/#{name}/#{version}"
         url << "?force=true" if force
 
-        client.connection.put(url, manifest)
+        response = client.connection.put(url, manifest)
+        raise response if response.is_a?(Exception)
+        response
       end
 
       def update(*args)

--- a/lib/ridley/resources/data_bag_item_resource.rb
+++ b/lib/ridley/resources/data_bag_item_resource.rb
@@ -83,8 +83,10 @@ module Ridley
       # @return [Ridley::DataBagItemResource]
       def update(client, data_bag, object)
         resource = new(client, data_bag, object.to_hash)
+        response = client.connection.put("#{data_bag.class.resource_path}/#{data_bag.name}/#{resource.chef_id}", resource.to_json)
+        raise if response.is_a?(Exception)
         new(client, data_bag).from_hash(
-          client.connection.put("#{data_bag.class.resource_path}/#{data_bag.name}/#{resource.chef_id}", resource.to_json).body
+          response.body
         )
       end
     end

--- a/lib/ridley/resources/sandbox_resource.rb
+++ b/lib/ridley/resources/sandbox_resource.rb
@@ -76,6 +76,7 @@ module Ridley
     # Notify the Chef Server that uploading to this sandbox has completed
     def commit
       response = client.connection.put("sandboxes/#{sandbox_id}", MultiJson.encode(is_completed: true)).body
+      raise response if response.is_a?(Exception)
       set_attribute(:is_completed, response[:is_completed])
     end
 


### PR DESCRIPTION
This captures ridley error exceptions and passes it back to the caller
to handle. It prevents the connection worker from being respawned and
attempting again when it will be an error better dealt with outside the
connection.

Some what related to: https://github.com/RiotGames/berkshelf/pull/323
