### PR TITLE
Accept an IO instead of a path in SandboxUploader#upload

### DIFF
--- a/spec/unit/ridley/sandbox_uploader_spec.rb
+++ b/spec/unit/ridley/sandbox_uploader_spec.rb
@@ -96,5 +96,31 @@ describe Ridley::SandboxUploader do
         subject.upload(chk_id, path).should be_nil
       end
     end
+
+    context "when the checksum is passed with an IO" do
+
+      let(:chk_id){ 'UnqwASktfBA=' }
+
+      let(:checksums) do
+        {
+          chk_id => {
+            url: "https://api.opscode.com/organizations/vialstudios/sandboxes/bd091b150b0a4578b97771af6abf3e05",
+            needs_upload: true
+          }
+        }
+      end
+
+      let(:sandbox) do
+        Ridley::SandboxResource.new(client, checksums: checksums)
+      end
+
+      it "accepts something that responds to read" do
+        stub_request(:put, checksums[chk_id][:url])
+        io = double("io")
+        io.should_receive(:read).once.and_return("Some content")
+        subject.upload(chk_id, io)
+      end
+
+    end
   end
 end


### PR DESCRIPTION
Hi

I'm currently developing a git plugin for ridley (https://github.com/hannesg/ridley-git) and currently try to upload cookbook files without doing a checkout. Therefore it would be cool if the responsible method accepts IO ducktypes.

Thank you
Hannes
