### PR TITLE
Improved syntax checker error output

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -170,10 +170,10 @@ module Ridley::Chef
     def validate
       raise IOError, "No Cookbook found at: #{path}" unless path.exist?
 
-      unless quietly { syntax_checker.validate_ruby_files }
+      unless syntax_checker.validate_ruby_files
         raise Ridley::Errors::CookbookSyntaxError, "Invalid ruby files in cookbook: #{cookbook_name} (#{version})."
       end
-      unless quietly { syntax_checker.validate_templates }
+      unless syntax_checker.validate_templates
         raise Ridley::Errors::CookbookSyntaxError, "Invalid template files in cookbook: #{cookbook_name} (#{version})."
       end
 

--- a/lib/ridley/chef/cookbook/syntax_check.rb
+++ b/lib/ridley/chef/cookbook/syntax_check.rb
@@ -125,7 +125,7 @@ module Ridley::Chef
       end
 
       def validate_template(erb_file)
-        result = shell_out("erubis -x #{erb_file} | ruby -c")
+        result = quietly { shell_out("erubis -x #{erb_file} | ruby -c") }
         result.error!
         true
       rescue Mixlib::ShellOut::ShellCommandFailed
@@ -136,7 +136,7 @@ module Ridley::Chef
       end
 
       def validate_ruby_file(ruby_file)
-        result = shell_out("ruby -c #{ruby_file}")
+        result = quietly { shell_out("ruby -c #{ruby_file}") }
         result.error!
         true
       rescue Mixlib::ShellOut::ShellCommandFailed


### PR DESCRIPTION
Hi,

I made two commits to change the syntax checker error messages.

The first one shows the cookbook version only once in the error message, instead of twice:
Before: 
`Ridley::Errors::CookbookSyntaxError Invalid template files in cookbook: ridley_test-0.1.0 (0.1.0).`
After: 
`Ridley::Errors::CookbookSyntaxError Invalid template files in cookbook: ridley_test (0.1.0).`

I think it simply increases readability.

The second one shows the actual syntax check errors on a failed check:
Before: 
`Ridley::Errors::CookbookSyntaxError Invalid template files in cookbook: ridley_test (0.1.0).
After: 
``Erb template templates/default/defect.erb has a syntax error: -:1: syntax error, unexpected '>' Ridley::Errors::CookbookSyntaxError Invalid template files in cookbook: ridley_test (0.1.0).``

This might get ugly with a lot of syntax errors, but we should at least point to user to file with the error.

The third commit includes a tiny refactor which imo improves readability, but that's arguable.

Since these aren't strictly improvements, let me know if anything should be changed.
