### PR TITLE
raise on #run action and not on initialization of Bootstrapper

### DIFF
--- a/lib/ridley/bootstrapper/context.rb
+++ b/lib/ridley/bootstrapper/context.rb
@@ -5,7 +5,6 @@ module Ridley
     # @author Jamie Winsor <reset@riotgames.com>
     class Context
       class << self
-
         # @param [String] host
         # @option options [Hash] :ssh
         #   * :user (String) a shell user that will login to each node and perform the bootstrap command on (required)
@@ -38,6 +37,8 @@ module Ridley
         #   bootstrap with sudo (default: true)
         # @option options [String] :template ('omnibus')
         #   bootstrap template to use
+        #
+        # @raise [Errors::HostConnectionError] if a node is unreachable
         def create(host, options = {})
           host_connector = HostConnector.best_connector_for(host, options)
           template_binding = case host_connector.to_s

--- a/lib/ridley/resources/node_resource.rb
+++ b/lib/ridley/resources/node_resource.rb
@@ -1,4 +1,4 @@
-module Ridley 
+module Ridley
   # @author Jamie Winsor <reset@riotgames.com>
   class NodeResource < Ridley::Resource
     class << self
@@ -114,8 +114,8 @@ module Ridley
     # attribute and value.
     #
     # @note It is not possible to set any other attribute level on a node and have it persist after
-    #   a Chef Run. This is because all other attribute levels are truncated at the start of a Chef Run. 
-    # 
+    #   a Chef Run. This is because all other attribute levels are truncated at the start of a Chef Run.
+    #
     # @example setting and saving a node level normal attribute
     #
     #   obj = node.find("jwinsor-1")
@@ -165,7 +165,7 @@ module Ridley
     #
     # @return [nil, String]
     def cloud_provider
-      self.cloud? ? self.automatic[:cloud][:provider] : nil      
+      self.cloud? ? self.automatic[:cloud][:provider] : nil
     end
 
     # Returns true if the node is identified as a cloud node.

--- a/spec/unit/ridley/bootstrapper_spec.rb
+++ b/spec/unit/ridley/bootstrapper_spec.rb
@@ -64,9 +64,29 @@ describe Ridley::Bootstrapper do
   end
 
   describe "#contexts" do
-    it "returns an array of Bootstrapper::Contexts" do
-      subject.contexts.should be_a(Array)
-      subject.contexts.should each be_a(Ridley::Bootstrapper::Context)
+    before do
+      Ridley::Bootstrapper::Context.stub(:create).and_return(double)
+    end
+
+    it "creates a new context for each host" do
+      Ridley::Bootstrapper::Context.should_receive(:create).exactly(nodes.length).times
+      subject.contexts
+    end
+
+    it "contains a item for each host" do
+      subject.contexts.should have(nodes.length).items
+    end
+
+    context "when a host is unreachable" do
+      before do
+        Ridley::Bootstrapper::Context.stub(:create).and_raise(Ridley::Errors::HostConnectionError)
+      end
+
+      it "raises a HostConnectionError" do
+        expect {
+          subject.contexts
+        }.to raise_error(Ridley::Errors::HostConnectionError)
+      end
     end
   end
 


### PR DESCRIPTION
It's nicer if initializers don't throw exceptions. This will create contexts on a bootstrapper when they are necessary.
