### PR TITLE
use the base IO class instead of maybe Celluloid::IO

### DIFF
--- a/lib/ridley/client.rb
+++ b/lib/ridley/client.rb
@@ -257,7 +257,7 @@ module Ridley
     def encrypted_data_bag_secret
       return nil if encrypted_data_bag_secret_path.nil?
 
-      IO.read(encrypted_data_bag_secret_path).chomp
+      ::IO.read(encrypted_data_bag_secret_path).chomp
     rescue Errno::ENOENT => e
       raise Errors::EncryptedDataBagSecretNotFound, "Encrypted data bag secret provided but not found at '#{encrypted_data_bag_secret_path}'"
     end


### PR DESCRIPTION
Celluloid::IO does not have a read method, so you end up with Celluloid eating that exception and having to dig around for 30 minutes to find out what caused it :smiley_cat: 
