### PR TITLE
Explicitly set metadata.name if it's missing

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -42,6 +42,10 @@ module Ridley::Chef
           metadata.name.empty? ? File.basename(path) : metadata.name
         end
 
+        if metadata.name.empty?
+            metadata.name(name)
+        end
+
         new(name, path, metadata)
       end
     end


### PR DESCRIPTION
Hit a few cookbooks from opscode that's missing the name attribute from metadata.rb. This explicitly sets it if it's missing. Referenced in https://github.com/RiotGames/ridley/issues/79
