### PR TITLE
Support for metadata.json fallback for non-existent metadata.rb

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -29,12 +29,18 @@ module Ridley::Chef
       #   explicitly supply the name of the cookbook we are loading. This is useful if
       #   you are dealing with a cookbook that does not have well-formed metadata
       #
-      # @raise [IOError] if the path does not contain a metadata.rb file
+      # @raise [IOError] if the path does not contain a metadata.rb or metadata.json file
       #
       # @return [Ridley::Chef::Cookbook]
       def from_path(path, options = {})
         path     = Pathname.new(path)
-        metadata = Cookbook::Metadata.from_file(path.join('metadata.rb'))
+        metadata = if path.join('metadata.rb').exist?
+          Cookbook::Metadata.from_file(path.join('metadata.rb'))
+        elsif path.join('metadata.json').exist?
+          Cookbook::Metadata.from_json(File.read(path.join('metadata.json')))
+        else
+          raise IOError, "no metadata.rb or metadata.json found at #{path}"
+        end
 
         metadata.name(options[:name].presence || metadata.name.presence || File.basename(path))
         new(metadata.name, path, metadata)

--- a/lib/ridley/chef/cookbook/metadata.rb
+++ b/lib/ridley/chef/cookbook/metadata.rb
@@ -26,6 +26,10 @@ module Ridley::Chef
         def from_hash(hash)
           new.from_hash(hash)
         end
+
+        def from_json(json)
+          new.from_json(json)
+        end
       end
 
       NAME              = 'name'.freeze
@@ -456,6 +460,10 @@ module Ridley::Chef
         @recipes          = o[RECIPES] if o.has_key?(RECIPES)
         @version          = o[VERSION] if o.has_key?(VERSION)
         self
+      end
+
+      def from_json(json)
+        from_hash MultiJson.decode(json)
       end
 
       private

--- a/spec/unit/ridley/chef/cookbook_spec.rb
+++ b/spec/unit/ridley/chef/cookbook_spec.rb
@@ -29,6 +29,7 @@ describe Ridley::Chef::Cookbook do
 
       context "when the metadata does not contain a value for name and no value for :name option was given" do
         let(:cookbook_path) { tmp_path.join("directory_name").to_s }
+
         before do
           FileUtils.mkdir_p(cookbook_path)
           FileUtils.touch(File.join(cookbook_path, 'metadata.rb'))
@@ -36,6 +37,21 @@ describe Ridley::Chef::Cookbook do
 
         it "sets the name of the cookbook to the name of the directory containing it" do
           subject.from_path(cookbook_path).cookbook_name.should eql("directory_name")
+        end
+      end
+
+      context "when a metadata.rb is missing but metadata.json is present", focus: true do
+        let(:cookbook_path) { tmp_path.join("temp_cookbook").to_s }
+
+        before do
+          FileUtils.mkdir_p(cookbook_path)
+          File.open(File.join(cookbook_path, 'metadata.json'), 'w+') do |f|
+            f.write MultiJson.encode(name: "rspec_test")
+          end
+        end
+
+        it "sets the name of the cookbook from the metadata.json" do
+          subject.from_path(cookbook_path).cookbook_name.should eql("rspec_test")
         end
       end
     end


### PR DESCRIPTION
Cookbooks do not neccessarily have metadata.rb files, although they are encouraged to and should, this is not enforced at least by the opscode community site. The majority do and use that to generate metadata.json, but it's the json file itself that chef uses, and hence there are some in the wild that do not contain a metadata.rb file (example: http://community.opscode.com/cookbooks/aide as of 0.1.1). Running into such an issue causes the metadata load to fail and berkshelf to not be able to support installing cookbooks with _only_ a metada.json

This isn't likely to affect many cookbooks, but when it does, the only other options are to fork the cookbook, or vendor the cookbook. This is probably a 'nice to have' class feature.

note: Moving from (https://github.com/RiotGames/berkshelf/issues/418)
