### PR TITLE
Windows Bootstrap Fails with "Cefcrypted_data_bag_secret"

### DIFF
--- a/lib/ridley/bootstrap_bindings/windows_template_binding.rb
+++ b/lib/ridley/bootstrap_bindings/windows_template_binding.rb
@@ -79,7 +79,7 @@ CONFIG
       end
 
       if encrypted_data_bag_secret.present?
-        body << %Q{encrypted_data_bag_secret "#{bootstrap_directory}\\encrypted_data_bag_secret"\n}
+        body << %Q{encrypted_data_bag_secret '#{bootstrap_directory}\\encrypted_data_bag_secret'\n}
       end
 
       escape_and_echo(body)


### PR DESCRIPTION
No such file or directory - file not found 'Cefcrypted_data_bag_secret'

windows_template_binding.rb writes out the client.rb. Since client.rb is actual ruby code, it fails because the path to the secret isn't escaped good enough.
