### PR TITLE
Fixed issue where files method on CookbookObject is occasionally overwritten.

### DIFF
--- a/lib/ridley/chef_objects/cookbook_object.rb
+++ b/lib/ridley/chef_objects/cookbook_object.rb
@@ -118,7 +118,7 @@ module Ridley
     #
     # @return [nil]
     def download_file(filetype, path, destination)
-      files = case filetype.to_sym
+      file_list = case filetype.to_sym
       when :attribute, :attributes; attributes
       when :definition, :definitions; definitions
       when :file, :files; files
@@ -132,7 +132,7 @@ module Ridley
         raise Errors::UnknownCookbookFileType.new(filetype)
       end
 
-      file  = files.find { |f| f[:path] == path }
+      file  = file_list.find { |f| f[:path] == path }
       return nil if file.nil?
 
       destination = File.expand_path(destination)


### PR DESCRIPTION
When running a `berks upload` I was getting the following error:

```
/home/jordan/.rvm/gems/ruby-1.9.3-p392/gems/ridley-0.11.1/lib/ridley/chef_objects/cookbook_object.rb:135:in `download_file': undefined method `find' for nil:NilClass (NoMethodError)
```

Tracked it down to this line in the code, seems that the 'files' method is occasionally getting replaced with nil. Changing the name of the 'files' variable seems to resolve the issue, so that's what I've done.
