### PR TITLE
offload loading of WinRM gem to instantiate of WinRM client

### DIFF
--- a/lib/ridley.rb
+++ b/lib/ridley.rb
@@ -1,11 +1,3 @@
-require 'active_support/core_ext/kernel/reporting'
-# Silencing warnings because not all versions of GSSAPI support all of the GSSAPI methods
-# the gssapi gem attempts to attach to and these warnings are dumped to STDERR.
-silence_warnings do
-  # Requiring winrm before all other gems because of https://github.com/WinRb/WinRM/issues/39
-  require 'winrm'
-end
-
 require 'active_support/inflector'
 require 'addressable/uri'
 require 'celluloid'

--- a/lib/ridley/host_connector/winrm/worker.rb
+++ b/lib/ridley/host_connector/winrm/worker.rb
@@ -87,6 +87,13 @@ module Ridley
         # @return [WinRM::WinRMWebService]
         def winrm
           @winrm_client ||= begin
+            require 'active_support/core_ext/kernel/reporting'
+            # Silencing warnings because not all versions of GSSAPI support all of the GSSAPI methods
+            # the gssapi gem attempts to attach to and these warnings are dumped to STDERR.
+            silence_warnings do
+              require 'winrm'
+            end
+
             client = ::WinRM::WinRMWebService.new(winrm_endpoint, :plaintext,
               user: user, pass: password, disable_sspi: true, basic_auth_only: true)
             client.set_timeout(6000)

--- a/spec/unit/ridley/host_connector/winrm/worker_spec.rb
+++ b/spec/unit/ridley/host_connector/winrm/worker_spec.rb
@@ -25,7 +25,9 @@ describe Ridley::HostConnector::WinRM::Worker do
   describe "#winrm" do
     subject { winrm_worker.winrm }
 
-    it { should be_a(WinRM::WinRMWebService) }
+    it "returns a WinRM::WinRMWebService" do
+      expect(subject).to be_a(::WinRM::WinRMWebService)
+    end
   end
 
   describe "#get_command" do
@@ -83,7 +85,7 @@ describe Ridley::HostConnector::WinRM::Worker do
       it "returns an :error with the response" do
         status, response = run
         expect(status).to eq(:error)
-        expect(response.stderr).to eq("stderr")        
+        expect(response.stderr).to eq("stderr")
       end
     end
 


### PR DESCRIPTION
@KAllan357 you should take a look at this to validate that https://github.com/WinRb/WinRM/issues/39 is no longer happening. I am not seeing it in the test suite of this branch.
