### PR TITLE
improve chef attribute access methods on NodeObject

### DIFF
--- a/lib/ridley/chef_objects/node_object.rb
+++ b/lib/ridley/chef_objects/node_object.rb
@@ -30,6 +30,14 @@ module Ridley
     alias_method :default_attributes, :default
     alias_method :override_attributes, :override
 
+    # A merged hash containing a deep merge of all of the attributes respecting the node attribute
+    # precedence level.
+    #
+    # @return [hashie::Mash]
+    def chef_attributes
+      default.merge(normal.merge(override.merge(automatic)))
+    end
+
     # Set a node level normal attribute given the dotted path representation of the Chef
     # attribute and value.
     #

--- a/spec/unit/ridley/chef_objects/node_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/node_object_spec.rb
@@ -5,6 +5,55 @@ describe Ridley::NodeObject do
   let(:instance) { described_class.new(resource) }
   subject { instance }
 
+  describe "#chef_attributes" do
+    subject { instance.chef_attributes }
+
+    it "returns a Hashie::Mash" do
+      expect(subject).to be_a(Hashie::Mash)
+    end
+
+    it "includes default attributes" do
+      instance.default = default = { default: { one: "val", two: "val" } }
+      expect(subject.to_hash).to include(default)
+    end
+
+    it "includes normal attributes" do
+      instance.normal = normal = { normal: { one: "new", two: "val" } }
+      expect(subject.to_hash).to include(normal)
+    end
+
+    it "includes override attributes" do
+      instance.override = override = { override: { one: "new", two: "val" } }
+      expect(subject.to_hash).to include(override)
+    end
+
+    it "includes automatic attributes" do
+      instance.automatic = automatic = { automatic: { one: "new", two: "val" } }
+      expect(subject.to_hash).to include(automatic)
+    end
+
+    it "overrides default attributes with normal attributes" do
+      instance.default = default = { one: "old", two: "old" }
+      instance.normal = normal = { one: "new" }
+      expect(subject[:one]).to eql("new")
+      expect(subject[:two]).to eql("old")
+    end
+
+    it "overrides normal attributes with override attributes" do
+      instance.normal = normal = { one: "old", two: "old" }
+      instance.override = override = { one: "new" }
+      expect(subject[:one]).to eql("new")
+      expect(subject[:two]).to eql("old")
+    end
+
+    it "overrides override attributes with automatic attributes" do
+      instance.override = override = { one: "old", two: "old" }
+      instance.automatic = automatic = { one: "new" }
+      expect(subject[:one]).to eql("new")
+      expect(subject[:two]).to eql("old")
+    end
+  end
+
   describe "#set_chef_attribute" do
     it "sets an normal node attribute at the nested path" do
        subject.set_chef_attribute('deep.nested.item', true)


### PR DESCRIPTION
- add NodeObject#chef_attributes which will return a properly deep merged hash of all the chef attributes of the node
- remove the setters for node attributes; they don't do anything but confuse people. Use NodeObject#set_chef_attribute to properly set an attribute on a node object.
