### PR TITLE
Catch WinRM::WinRMHTTPTransportError in the cleanup block

### DIFF
--- a/lib/ridley/host_connector/winrm.rb
+++ b/lib/ridley/host_connector/winrm.rb
@@ -80,7 +80,11 @@ module Ridley
           end
         end
       ensure
-        command_uploaders.map(&:cleanup)
+        begin
+          command_uploaders.map(&:cleanup)
+        rescue ::WinRM::WinRMHTTPTransportError => ex
+          log.info "Error cleaning up leftover Powershell scripts on some hosts"
+        end
       end
 
       # Returns the command if it does not break the WinRM command length


### PR DESCRIPTION
Closes #187 
