### PR TITLE
Catch another source of winrm errors

### DIFF
--- a/lib/ridley/host_connector/winrm.rb
+++ b/lib/ridley/host_connector/winrm.rb
@@ -47,10 +47,10 @@ module Ridley
         end
 
         HostConnector::Response.new(host).tap do |response|
-          command_uploaders << command_uploader = CommandUploader.new(connection)
-          command = get_command(command, command_uploader)
-
           begin
+            command_uploaders << command_uploader = CommandUploader.new(connection)
+            command = get_command(command, command_uploader)
+
             log.info "Running WinRM Command: '#{command}' on: '#{host}' as: '#{user}'"
 
             defer {


### PR DESCRIPTION
Initialize attempts to make winrm calls
