### PR TITLE
moved "Node Resource" heading to above the node stuff...typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ Unlike a role, node, client, or environment, a data bag is a container for other
       #<Ridley::DataBagItemObject: chef_id:appconfig, host="reset.local", user="jamie">
 
 ## Environment Resource
-## Node Resource
 ### Setting Attributes
 
 Setting a default environment attribute is just like setting a node level default attribute
@@ -264,6 +263,7 @@ And the same goes for setting an environment level override attribute
     production_env.set_override_attribute("my_app.proxy.enabled", false)
     production_env.save #=> true
 
+## Node Resource
 ### Bootstrapping Unix nodes
 
     ridley = Ridley.new(


### PR DESCRIPTION
Confusing heading placement typo...this fix makes sense to me.
