### PR TITLE
set the task_class to Thread in CookbookResource

### DIFF
--- a/lib/ridley/resources/cookbook_resource.rb
+++ b/lib/ridley/resources/cookbook_resource.rb
@@ -1,5 +1,7 @@
 module Ridley
   class CookbookResource < Ridley::Resource
+    task_class TaskThread
+
     set_resource_path "cookbooks"
     represented_by Ridley::CookbookObject
 


### PR DESCRIPTION
this will prevent resource crashes during deserialization of cookbook objects

See https://github.com/RiotGames/vagrant-berkshelf/issues/51 for details

This should also be merged into the 1.2-stable branch and a 1.2.5 release should go out to ensure Berkshelf 2 users get this fix.
