### PR TITLE
Prevent access denied errors on Windows when downloading cookbooks.

### DIFF
--- a/lib/ridley/connection.rb
+++ b/lib/ridley/connection.rb
@@ -156,7 +156,7 @@ module Ridley
 
       local.flush
 
-      FileUtils.mv(local.path, destination)
+      FileUtils.cp(local.path, destination)
     rescue OpenURI::HTTPError => ex
       abort(ex)
     ensure


### PR DESCRIPTION
This sample script:

```
require 'ridley'

ridley = Ridley.new(
    server_url: "https://my_server",
    client_name: "my_client",
    client_key: "my_client.pem",
    ssl: {
        verify: false
    }
)

cookbook = ridley.cookbook.satisfy('apt', '= 1.7.0')
version_found = cookbook.version
path = cookbook.download

puts "downloaded version #{version_found} to #{path}"
```

produces this error when executed on a Windows system:

```
C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:519:in `rename': Permission denied - (C:/Users/keiths/AppData/Local/Temp/1/ridley-stream20130904-4272-1bojvnq, C:/Users/keiths/AppData/Local/Temp/1/d20130904-4272-oq42x/resources/preference.rb) (Errno::EACCES)
  from C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:519:in `block in mv'
  from C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:1515:in `block in fu_each_src_dest'
  from C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:1531:in `fu_each_src_dest0'
  from C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:1513:in `fu_each_src_dest'
  from C:/Ruby193/lib/ruby/1.9.1/fileutils.rb:508:in `mv'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/ridley-1.2.5/lib/ridley/connection.rb:159:in `stream'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `public_send'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `dispatch'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:67:in `dispatch'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/actor.rb:326:in `block in handle_message'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/tasks.rb:42:in `block in initialize'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/tasks/task_thread.rb:21:in `block in create'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/internal_pool.rb:59:in `call'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/internal_pool.rb:59:in `block in create'
  from (celluloid):0:in `remote procedure call'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:95:in `value'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/proxies/sync_proxy.rb:28:in `method_missing'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/legacy.rb:14:in `method_missing'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/proxies/actor_proxy.rb:25:in `_send_'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/pool_manager.rb:41:in `_send_'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/pool_manager.rb:122:in `method_missing'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `public_send'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `dispatch'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:67:in `dispatch'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/actor.rb:326:in `block in handle_message'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/tasks.rb:42:in `block in initialize'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/tasks/task_fiber.rb:11:in `block in create'
  from (celluloid):0:in `remote procedure call'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:95:in `value'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/proxies/sync_proxy.rb:28:in `method_missing'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/celluloid-0.14.1/lib/celluloid/legacy.rb:14:in `method_missing'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/ridley-1.2.5/lib/ridley/chef_objects/cookbook_object.rb:140:in `download_file'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/ridley-1.2.5/lib/ridley/chef_objects/cookbook_object.rb:90:in `block (2 levels) in download'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/ridley-1.2.5/lib/ridley/chef_objects/cookbook_object.rb:87:in `each'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/ridley-1.2.5/lib/ridley/chef_objects/cookbook_object.rb:87:in `block in download'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/ridley-1.2.5/lib/ridley/chef_objects/cookbook_object.rb:84:in `each'
  from E:/RubyScripts/ridleytest/vendor/bundle/ruby/1.9.1/gems/ridley-1.2.5/lib/ridley/chef_objects/cookbook_object.rb:84:in `download'
  from E:/RubyScripts/ridleytest/ridleytest2.rb:14:in `<top (required)>'
  from -e:1:in `load'
  from -e:1:in `<main>'
```

connection.rb was attempting to move the temp file it had downloaded from the chef server to it's final location (which is another folder also in the temp directory).  The move fails because the file is still open when the attempt is made.  I changed mv to cp to get around this.  The temp file will still be cleaned up due to the existing ensure block. There will momentarily be 2 copies of each file now, but this should not be a problem since the original temporary copy will be deleted immediately after the copy is completed.
