### PR TITLE
Prevent access denied errors on Windows when downloading cookbooks

### DIFF
--- a/lib/ridley/connection.rb
+++ b/lib/ridley/connection.rb
@@ -156,7 +156,7 @@ module Ridley
 
       local.flush
 
-      FileUtils.mv(local.path, destination)
+      FileUtils.cp(local.path, destination)
     rescue OpenURI::HTTPError => ex
       abort(ex)
     ensure


### PR DESCRIPTION
Same change as was made in [this pull request](https://github.com/RiotGames/ridley/pull/212), except for the master branch.
