### PR TITLE
Handle another error in HostCommander

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 group :test do
   gem 'thor'
   gem 'rake', '>= 0.9.2.2'
-  gem 'rspec'
+  gem 'rspec', '~> 2.14.0'
   gem 'fuubar'
   gem 'json_spec'
   gem 'webmock'

--- a/lib/ridley/host_commander.rb
+++ b/lib/ridley/host_commander.rb
@@ -212,7 +212,7 @@ module Ridley
         defer {
           timeout(wait_time || PORT_CHECK_TIMEOUT) { Celluloid::IO::TCPSocket.new(host, port).close; true }
         }
-      rescue Timeout::Error, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EADDRNOTAVAIL => ex
+      rescue Errno::ETIMEDOUT, Timeout::Error, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EADDRNOTAVAIL => ex
         false
       end
 


### PR DESCRIPTION
I recently experienced an error shown in the following snippet of the trace:

```
[2013-08-22T23:42:39Z] PID[11301] TID[ieu44] ERROR: Ridley::HostCommander crashed!
Errno::ETIMEDOUT: Connection timed out - connect(2)
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-io-0.14.1/lib/celluloid/io/tcp_socket.rb:85:in `connect_nonblock'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-io-0.14.1/lib/celluloid/io/tcp_socket.rb:85:in `initialize'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/ridley-1.3.2/lib/ridley/host_commander.rb:213:in `new'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/ridley-1.3.2/lib/ridley/host_commander.rb:213:in `block (2 levels) in connector_port_open?'
```

I realize this is an older version of Ridley, but the lines in question have not changed between these releases. According to the docs for the [Socket class](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/socket/rdoc/Socket.html), `Errno::ETIMEDOUT` can be thrown, so we should attempt to handle it.

Also, I ended up with some test failures, because I hadn't executed `bundle update` in a while, and at some point code was added that was rspec 2.14.X specific. I think it makes sense to attempt to nail down a specific version of rspec and increase it as necessary.
