### PR TITLE
Celluloid 0.15.0 and HostCommander error

### DIFF
--- a/lib/ridley/host_commander.rb
+++ b/lib/ridley/host_commander.rb
@@ -210,7 +210,7 @@ module Ridley
       # @return [Boolean]
       def connector_port_open?(host, port, wait_time = nil)
         defer {
-          timeout(wait_time || PORT_CHECK_TIMEOUT) { Celluloid::IO::TCPSocket.new(host, port).close; true }
+          Timeout.timeout(wait_time || PORT_CHECK_TIMEOUT) { Celluloid::IO::TCPSocket.new(host, port).close; true }
         }
       rescue Errno::ETIMEDOUT, Timeout::Error, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EADDRNOTAVAIL => ex
         false


### PR DESCRIPTION
Given the following code:

```
require 'ridley'
host_commander = Ridley::HostCommander.new
host_commander.run("some ip address", "dir", winrm: {user: "foo", password: "bar"})
```

You'll get an error that looks like...

```
E, [2013-09-17T18:06:57.952377 #31456] ERROR -- : Ridley::HostCommander crashed!
NoMethodError: private method `timeout' called for nil:NilClass
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid.rb:419:in `timeout'
    /Users/kallan/src/ridley/lib/ridley/host_commander.rb:213:in `block in connector_port_open?'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `call'
    /Users/kallan/.rbenv/versions/2.0.NoMethodError: private method `timeout' called for nil:NilClass
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid.rb:419:in `timeout'
    from /Users/kallan/src/ridley/lib/ridley/host_commander.rb:213:in `block in connector_port_open?'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `call'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `public_send'
    from /Users/kallan/.rbenv/versio0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `public_send'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `dispatch'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:67:in `dispatch'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/future.rb:14:in `block in new'
    /Users/kallan/.rbenv/versions/2.0.ns/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `dispatch'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:67:in `dispatch'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/future.rb:14:in `block in new'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/thread_handle.rb:13:in `block in initialize'
    from0-p247/l /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/internal_pool.rb:100:in `call'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/internal_pool.rb:100:in `block in create'
    from (celluloid):0:in `remote procedure call'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/future.rb:104:in `value'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.ib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/thread_handle.rb:13:in `block in initialize'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/internal_pool.rb:100:in `call'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/internal_pool.rb:100:in `block in create'
    (celluloid):0:in `remote procedure call'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/fut0.0/gems/celluloid-0.15.1/lib/celluloid/future.rb:68:in `value'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid.rb:452:in `defer'
    from /Users/kallan/src/ridley/lib/ridley/host_commander.rb:212:in `connector_port_open?'
    from /Users/kallan/src/ridley/lib/ridley/host_commander.rb:177:in `connector_for'
    from /Users/kallan/src/ridley/lib/ridley/host_commander.rb:193:in `execute'
    from /Users/kallan/src/ridley/lib/ridley/host_commander.rb:43:in `run'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `public_send'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `dispatch'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloidure.rb:104:in `value'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/future.rb:68:in `value'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid.rb:452:in `defer'
    /Users/kallan/src/ridley/lib/ridley/host_commander.rb:212:in `connector_port_open?'
    /Users/kallan/src/ridley/lib/ridley/host_commander.rb:177:in `connector_for'
    /Users/kallan/src/ridley/lib/ridley/host_commander.rb:193:in `execute'
    /Users/kallan/sr/calls.rb:67:in `dispatch'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/actor.rb:322:in `block in handle_message'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/actor.rb:416:in `block in task'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/tasks.rb:55:in `block in initialize'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.c/ridley/lib/ridley/host_commander.rb:43:in `run'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `public_send'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:25:in `dispatch'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:67:in `dispatch'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/actor.rb:322:in `block in handle_message'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/actor.rb:416:in `block in task'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/tasks.rb:55:in `block in initialize'
    /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/tasks/task_fiber.rb:13:in `block in create'
0/gems/celluloid-0.15.1/lib/celluloid/tasks/task_fiber.rb:13:in `block in create'
    from (celluloid):0:in `remote procedure call'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/calls.rb:92:in `value'
    from /Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/celluloid-0.15.1/lib/celluloid/proxies/sync_proxy.rb:33:in `method_missing'
    from (irb):9

```
