### PR TITLE
Fix regression in Connection#stream

### DIFF
--- a/lib/ridley/connection.rb
+++ b/lib/ridley/connection.rb
@@ -122,6 +122,8 @@ module Ridley
     #   a URL to stream the response body from
     # @param [String] destination
     #   a location on disk to stream the content of the response body to
+    #
+    # @return [Boolean] true when the destination file exists
     def stream(target, destination)
       FileUtils.mkdir_p(File.dirname(destination))
 
@@ -157,6 +159,7 @@ module Ridley
       local.flush
 
       FileUtils.cp(local.path, destination)
+      File.exists?(destination)
     rescue OpenURI::HTTPError => ex
       abort(ex)
     ensure

--- a/spec/unit/ridley/connection_spec.rb
+++ b/spec/unit/ridley/connection_spec.rb
@@ -65,6 +65,10 @@ describe Ridley::Connection do
       File.exist?(destination).should be_true
     end
 
+    it "returns true when the file was copied" do
+      expect(subject.stream(target, destination)).to be_true
+    end
+
     it "contains the contents of the response body" do
       subject.stream(target, destination)
 


### PR DESCRIPTION
This method used to use FileUtils.mv which returned the exit code of the move operation. Now
that the method is using FileUtils.cp, it always returns nil.
