### PR TITLE
json metadata should be preferred over ruby metadata

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -33,12 +33,12 @@ module Ridley::Chef
       # @return [Ridley::Chef::Cookbook]
       def from_path(path, options = {})
         path     = Pathname.new(path)
-        metadata = if path.join('metadata.rb').exist?
-          Cookbook::Metadata.from_file(path.join('metadata.rb'))
-        elsif path.join('metadata.json').exist?
-          Cookbook::Metadata.from_json(File.read(path.join('metadata.json')))
+        metadata = if (metadata_file = path.join('metadata.json')).exist?
+          Cookbook::Metadata.from_json(File.read(metadata_file))
+        elsif (metadata_file = path.join('metadata.rb')).exist?
+          Cookbook::Metadata.from_file(metadata_file)
         else
-          raise IOError, "no metadata.rb or metadata.json found at #{path}"
+          raise IOError, "no metadata.json or metadata.rb found at #{path}"
         end
 
         metadata.name(options[:name].presence || metadata.name.presence || File.basename(path))

--- a/spec/unit/ridley/chef/cookbook_spec.rb
+++ b/spec/unit/ridley/chef/cookbook_spec.rb
@@ -40,18 +40,42 @@ describe Ridley::Chef::Cookbook do
         end
       end
 
-      context "when a metadata.rb is missing but metadata.json is present" do
+      context "when a metadata.json is missing but metadata.rb is present" do
         let(:cookbook_path) { tmp_path.join("temp_cookbook").to_s }
 
         before do
           FileUtils.mkdir_p(cookbook_path)
-          File.open(File.join(cookbook_path, 'metadata.json'), 'w+') do |f|
-            f.write JSON.fast_generate(name: "rspec_test")
+          File.open(File.join(cookbook_path, 'metadata.rb'), 'w+') do |f|
+            f.write <<-EOH
+              name 'rspec_test'
+            EOH
           end
         end
 
-        it "sets the name of the cookbook from the metadata.json" do
+        it "sets the name of the cookbook from the metadata.rb" do
           subject.from_path(cookbook_path).cookbook_name.should eql("rspec_test")
+        end
+      end
+
+      context "when a metadata.json and metadata.rb are both present" do
+        let(:cookbook_path) { tmp_path.join("temp_cookbook").to_s }
+
+        before do
+          FileUtils.mkdir_p(cookbook_path)
+
+          File.open(File.join(cookbook_path, 'metadata.json'), 'w+') do |f|
+            f.write JSON.fast_generate(name: "json_metadata")
+          end
+
+          File.open(File.join(cookbook_path, 'metadata.rb'), 'w+') do |f|
+            f.write <<-EOH
+              name 'ruby_metadata'
+            EOH
+          end
+        end
+
+        it "prefers the metadata.json" do
+          subject.from_path(cookbook_path).cookbook_name.should eql("json_metadata")
         end
       end
     end


### PR DESCRIPTION
In all cases the compiled metadata should be preferred by clients over the Ruby representation. The current behaviour of the Chef-Client reads the metadata.rb first (and that's why I originally wrote it this way), but I discussed this with @danielsdeleo and he agreed that it is not the correct behaviour.

See:
- https://tickets.opscode.com/browse/CHEF-4811
- https://tickets.opscode.com/browse/CHEF-4810

/cc @ivey @sethvargo @KAllan357 
