### PR TITLE
Remove usage of Hash#slice

### DIFF
--- a/lib/ridley/client.rb
+++ b/lib/ridley/client.rb
@@ -1,3 +1,5 @@
+require 'ridley/helpers'
+
 module Ridley
   class Client
     class ConnectionSupervisor < ::Celluloid::SupervisionGroup
@@ -7,7 +9,7 @@ module Ridley
           options[:server_url],
           options[:client_name],
           options[:client_key],
-          options.slice(*Ridley::Connection::VALID_OPTIONS)
+          Ridley::Helpers.options_slice(options, *Ridley::Connection::VALID_OPTIONS)
         ], as: :connection_pool)
       end
     end
@@ -17,14 +19,14 @@ module Ridley
         super(registry)
         supervise_as :client_resource, Ridley::ClientResource, connection_registry
         supervise_as :cookbook_resource, Ridley::CookbookResource, connection_registry,
-          options[:client_name], options[:client_key], options.slice(*Ridley::Connection::VALID_OPTIONS)
+          options[:client_name], options[:client_key], Ridley::Helpers.options_slice(options, *Ridley::Connection::VALID_OPTIONS)
         supervise_as :data_bag_resource, Ridley::DataBagResource, connection_registry,
           options[:encrypted_data_bag_secret]
         supervise_as :environment_resource, Ridley::EnvironmentResource, connection_registry
         supervise_as :node_resource, Ridley::NodeResource, connection_registry, options
         supervise_as :role_resource, Ridley::RoleResource, connection_registry
         supervise_as :sandbox_resource, Ridley::SandboxResource, connection_registry,
-          options[:client_name], options[:client_key], options.slice(*Ridley::Connection::VALID_OPTIONS)
+          options[:client_name], options[:client_key], Ridley::Helpers.options_slice(options, *Ridley::Connection::VALID_OPTIONS)
         supervise_as :search_resource, Ridley::SearchResource, connection_registry
         supervise_as :user_resource, Ridley::UserResource, connection_registry
       end

--- a/lib/ridley/connection.rb
+++ b/lib/ridley/connection.rb
@@ -3,6 +3,8 @@ require 'retryable'
 require 'tempfile'
 require 'zlib'
 
+require 'ridley/helpers'
+
 module Ridley
   class Connection < Faraday::Connection
     include Celluloid
@@ -65,7 +67,7 @@ module Ridley
         b.adapter :net_http_persistent
       end
 
-      uri_hash = Addressable::URI.parse(server_url).to_hash.slice(:scheme, :host, :port)
+      uri_hash = Ridley::Helpers.options_slice(Addressable::URI.parse(server_url).to_hash, :scheme, :host, :port)
 
       unless uri_hash[:port]
         uri_hash[:port] = (uri_hash[:scheme] == "https" ? 443 : 80)

--- a/lib/ridley/helpers.rb
+++ b/lib/ridley/helpers.rb
@@ -1,0 +1,10 @@
+module Ridley
+  module Helpers
+    def self.options_slice(options, *keys)
+      keys.inject({}) do |memo, key|
+        memo[key] = options[key] if options.include?(key)
+        memo
+      end
+    end
+  end
+end

--- a/lib/ridley/middleware/retry.rb
+++ b/lib/ridley/middleware/retry.rb
@@ -1,3 +1,5 @@
+require 'ridley/helpers'
+
 module Ridley
   # Catches exceptions and retries each request a limited number of times.
   #
@@ -19,7 +21,7 @@ module Ridley
     #   the list of exceptions to handle
     def initialize(app, options = {})
       super(app)
-      @options  = options.slice(:max, :interval, :exceptions)
+      @options  = Ridley::Helpers.options_slice(options, :max, :interval, :exceptions)
       @errmatch = build_exception_matcher(@options[:exceptions])
     end
 

--- a/lib/ridley/resources/cookbook_resource.rb
+++ b/lib/ridley/resources/cookbook_resource.rb
@@ -1,3 +1,5 @@
+require 'ridley/helpers'
+
 module Ridley
   class CookbookResource < Ridley::Resource
     task_class TaskThread
@@ -187,7 +189,7 @@ module Ridley
     # @return [Hash]
     def upload(path, options = {})
       options  = options.reverse_merge(validate: true, force: false, freeze: false)
-      cookbook = Ridley::Chef::Cookbook.from_path(path, options.slice(:name))
+      cookbook = Ridley::Chef::Cookbook.from_path(path, Ridley::Helpers.options_slice(options, :name))
 
       unless (existing = find(cookbook.cookbook_name, cookbook.version)).nil?
         if existing.frozen? && options[:force] == false
@@ -229,7 +231,7 @@ module Ridley
 
       sandbox.upload(checksums)
       sandbox.commit
-      update(cookbook, options.slice(:force, :freeze))
+      update(cookbook, Ridley::Helpers.options_slice(options, :force, :freeze))
     ensure
       # Destroy the compiled metadata only if it was created
       File.delete(compiled_metadata) unless compiled_metadata.nil?


### PR DESCRIPTION
Hash#slice, at least for me, is coming from the i18n gem (by way of Vagrant) and this seems to have different semantics from what the Ridley code expects. Specifically it appears the buff-extensions version won't throw an error if a given key isn't found, while with i18n it will. In general having a library that relies on non-standardized core extensions is :-(

The original traceback is:

```
/usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n/core_ext/hash.rb:4:in `fetch': key not found: :retries (KeyError)
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n/core_ext/hash.rb:4:in `block in slice'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n/core_ext/hash.rb:4:in `each'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n/core_ext/hash.rb:4:in `slice'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.5.1/lib/ridley/client.rb:10:in `initialize'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:25:in `public_send'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:25:in `dispatch'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:67:in `dispatch'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb:322:in `block in handle_message'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb:416:in `block in task'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/tasks.rb:55:in `block in initialize'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/tasks/task_fiber.rb:13:in `block in create'
    from (celluloid):0:in `remote procedure call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:92:in `value'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/proxies/sync_proxy.rb:33:in `method_missing'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/proxies/actor_proxy.rb:20:in `_send_'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid.rb:189:in `new'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.5.1/lib/ridley/client.rb:146:in `initialize'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:25:in `public_send'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:25:in `dispatch'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:67:in `dispatch'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb:322:in `block in handle_message'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb:416:in `block in task'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/tasks.rb:55:in `block in initialize'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/tasks/task_fiber.rb:13:in `block in create'
    from (celluloid):0:in `remote procedure call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:92:in `value'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/proxies/sync_proxy.rb:33:in `method_missing'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid/proxies/actor_proxy.rb:20:in `_send_'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/celluloid-0.15.2/lib/celluloid.rb:189:in `new'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.5.1/lib/ridley/client.rb:35:in `open'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ridley-2.5.1/lib/ridley.rb:51:in `open'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/downloader.rb:72:in `try_download'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/downloader.rb:37:in `block in download'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/downloader.rb:36:in `each'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/downloader.rb:36:in `download'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/installer.rb:64:in `block in run'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/installer.rb:53:in `collect'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/installer.rb:53:in `run'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/berksfile.rb:353:in `install'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/berkshelf-3.0.0.beta6/lib/berkshelf/berksfile.rb:574:in `vendor'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-berkshelf-8fca7b2f0089/lib/berkshelf/vagrant/action/install.rb:46:in `install'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-berkshelf-8fca7b2f0089/lib/berkshelf/vagrant/action/install.rb:30:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/provision.rb:52:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/clear_forwarded_ports.rb:13:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/set_name.rb:19:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/clean_machine_folder.rb:17:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/check_accessible.rb:18:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builder.rb:116:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `block in run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/util/busy.rb:19:in `busy'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/call.rb:51:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builder.rb:116:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `block in run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/util/busy.rb:19:in `busy'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/call.rb:51:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builder.rb:116:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `block in run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/util/busy.rb:19:in `busy'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/call.rb:51:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/call.rb:57:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-berkshelf-8fca7b2f0089/lib/berkshelf/vagrant/action/configure_chef.rb:23:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-berkshelf-8fca7b2f0089/lib/berkshelf/vagrant/action/load_shelf.rb:28:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/Cellar/rbenv/0.4.0/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-berkshelf-8fca7b2f0089/lib/berkshelf/vagrant/action/set_ui.rb:12:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/env_set.rb:19:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/call.rb:57:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builder.rb:116:in `call'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `block in run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/util/busy.rb:19:in `busy'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:69:in `run'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/machine.rb:147:in `action'
    from /usr/local/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/batch_action.rb:63:in `block (2 levels) in run'
```
