### PR TITLE
Reading JSON metadata files as UTF-8

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module Ridley::Chef
   class Cookbook
     require_relative 'cookbook/metadata'
@@ -34,7 +36,7 @@ module Ridley::Chef
       def from_path(path, options = {})
         path     = Pathname.new(path)
         metadata = if (metadata_file = path.join(Metadata::COMPILED_FILE_NAME)).exist?
-          Cookbook::Metadata.from_json(File.read(metadata_file, encoding: 'utf-8'))
+          Cookbook::Metadata.from_json(File.read(metadata_file))
         elsif (metadata_file = path.join(Metadata::RAW_FILE_NAME)).exist?
           Cookbook::Metadata.from_file(metadata_file)
         else


### PR DESCRIPTION
I've recently used Berkshelf to install some cookbooks and it just so happens that the 'iis' cookbook's metadata contained some non-ascii characters (specifically, some sort of apostrophe).

This solved the issue, and does not seem to cause any harm (which is not overly surprising).

I'll admit I did not have time to figure out if this needs to go elsewhere, so I'm open to suggestions.
