### PR TITLE
Lock down Hashie version.

### DIFF
--- a/ridley.gemspec
+++ b/ridley.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid-io',            '~> 0.16.0.pre'
   s.add_dependency 'erubis'
   s.add_dependency 'faraday',                 '~> 0.9.0'
-  s.add_dependency 'hashie',                  '>= 2.0.2', '< 3.0.0'
   s.add_dependency 'json',                    '>= 1.7.7'
   s.add_dependency 'mixlib-authentication',   '>= 1.3.0'
   s.add_dependency 'net-http-persistent',     '>= 2.8'


### PR DESCRIPTION
The new version of Hashie (3.0) changes dependencies, and is currently in development. We should ensure we're using a version before 3.0 until the issues are resolved in a better way.
