### PR TITLE
Allow connections to non-hosted servers that have a path in their URI

### DIFF
--- a/lib/ridley/connection.rb
+++ b/lib/ridley/connection.rb
@@ -67,18 +67,14 @@ module Ridley
         b.adapter :net_http_persistent
       end
 
-      uri_hash = Ridley::Helpers.options_slice(Addressable::URI.parse(server_url).to_hash, :scheme, :host, :port)
+      uri_hash = Ridley::Helpers.options_slice(Addressable::URI.parse(server_url).to_hash, :scheme, :host, :port, :path)
 
       unless uri_hash[:port]
         uri_hash[:port] = (uri_hash[:scheme] == "https" ? 443 : 80)
       end
 
-      if org_match = server_url.match(/.*\/organizations\/(.*)/)
+      if org_match = uri_hash[:path].match(/^\/organizations\/(.*)/)
         @organization = org_match[1]
-      end
-
-      unless @organization.nil?
-        uri_hash[:path] = "/organizations/#{@organization}"
       end
 
       super(Addressable::URI.new(uri_hash), options)

--- a/spec/unit/ridley/client_spec.rb
+++ b/spec/unit/ridley/client_spec.rb
@@ -34,7 +34,7 @@ describe Ridley::Client do
       describe "parsing the 'server_url' option" do
         its(:host) { should eql("api.opscode.com") }
         its(:scheme) { should eql("https") }
-        its(:path_prefix) { should eql("/") }
+        its(:path_prefix) { should eql("/some_path") }
       end
 
       describe "with a server_url containing an organization" do
@@ -51,7 +51,7 @@ describe Ridley::Client do
           subject.organization.should eql(organization)
         end
 
-        it "sets the 'path_prefix' of the connection the organization sub URI" do
+        it "sets the 'path_prefix' of the connection to the organization sub URI" do
           subject.path_prefix.should eql("/organizations/#{organization}")
         end
       end


### PR DESCRIPTION
I was trying to connect to a server at `http://<address>/chef`, however Ridley kept sending requests to `http://<address>`, ignoring the specified path.

Hopefully this should fix that :)
