### PR TITLE
Fix a encoding bug (Windows)

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -33,7 +33,7 @@ module Ridley::Chef
         path = Pathname.new(path)
 
         if (file = path.join(Metadata::COMPILED_FILE_NAME)).exist?
-          metadata = Metadata.from_json(File.read(file))
+          metadata = Metadata.from_json(File.read(file, :encoding => Encoding::UTF_8))
         elsif (file = path.join(Metadata::RAW_FILE_NAME)).exist?
           metadata = Metadata.from_file(file)
         else


### PR DESCRIPTION
Hello. I use Chef Development Kit on Windows 8.1 (x64). I've find a bug that isn't able to load `metadata.json` of some types. Maybe this bug is occurs in only Japanese Windows.

This is error message.
```
C:\Users\pine\Dropbox\Document\Repositories\chef-repo>chef exec berks vendor cookbooks
C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/json-1.8.1/lib/json/common.rb:155:in `encode': "\x94" followed by " " on Windows-31J (Encoding::InvalidByteSequenceError)
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/json-1.8.1/lib/json/common.rb:155:in `initialize'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/json-1.8.1/lib/json/common.rb:155:in `new'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/json-1.8.1/lib/json/common.rb:155:in `parse'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/ridley-4.1.0/lib/ridley/chef/cookbook/metadata.rb:458:in `from_json'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/ridley-4.1.0/lib/ridley/chef/cookbook/metadata.rb:29:in `from_json'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/ridley-4.1.0/lib/ridley/chef/cookbook.rb:36:in `from_path'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cached_cookbook.rb:15:in `from_store_path'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cookbook_store.rb:108:in `block in cookbooks'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cookbook_store.rb:98:in `collect'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cookbook_store.rb:98:in `cookbooks'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cookbook_store.rb:163:in `satisfy'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/dependency.rb:139:in `cached_cookbook'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/lockfile.rb:399:in `block in reduce!'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/lockfile.rb:384:in `each'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/lockfile.rb:384:in `reduce!'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/installer.rb:32:in `run'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/berksfile.rb:370:in `install'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/berksfile.rb:579:in `block in vendor'
	from C:/opscode/chefdk/embedded/lib/ruby/2.0.0/tmpdir.rb:88:in `mktmpdir'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/berksfile.rb:577:in `vendor'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cli.rb:387:in `vendor'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cli.rb:52:in `dispatch'
	from C:/opscode/chefdk/embedded/lib/ruby/gems/2.0.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from C:/opscode/chefdk/embedded/apps/berkshelf/lib/berkshelf/cli.rb:27:in `execute!'
	from C:/opscode/chefdk/embedded/apps/berkshelf/bin/berks:5:in `<top (required)>'
	from C:/opscode/chefdk/bin/berks:38:in `load'
	from C:/opscode/chefdk/bin/berks:38:in `<main>'
```


In `lib/ridley/chef/cookbook.rb` L35-36.
```ruby
        if (file = path.join(Metadata::COMPILED_FILE_NAME)).exist?
          metadata = Metadata.from_json(File.read(file))
```

In Japanese Windows, `File.read(file)` returns a string encoded by `Windows-31J`.

```ruby
p File.read(file).encoding
# => #<Encoding:Windows-31J>
```

There is the cookbook that occurs error.
- smf-2.2.1<br />
https://supermarket.chef.io/cookbooks/smf

This is my environment.

```
C:\Users\pine>chef --version
Chef Development Kit Version: 0.3.5

C:\Users\pine>chef verify
Running verification for component 'berkshelf'
Running verification for component 'test-kitchen'
Running verification for component 'chef-client'
Running verification for component 'chef-dk'
Running verification for component 'chefspec'
.................................................
---------------------------------------------
Verification of component 'chefspec' succeeded.
Verification of component 'test-kitchen' succeeded.
Verification of component 'chef-dk' succeeded.
Verification of component 'berkshelf' succeeded.
Verification of component 'chef-client' succeeded.

C:\Users\pine>where berks
C:\opscode\chefdk\bin\berks
C:\opscode\chefdk\bin\berks.bat

C:\Users\pine>berks --version
3.2.1
```

Thank you.