### PR TITLE
Add SSL verify option by from_chef_config method.

### DIFF
--- a/lib/ridley.rb
+++ b/lib/ridley.rb
@@ -45,6 +45,9 @@ module Ridley
       config[:validator_path]   = config.delete(:validation_key)
       config[:client_name]      = config.delete(:node_name)
       config[:server_url]       = config.delete(:chef_server_url)
+      if config[:ssl_verify_mode] == :verify_none
+        config[:ssl] = {verify: false}
+      end
 
       Client.new(config.merge(options))
     end

--- a/spec/unit/ridley_spec.rb
+++ b/spec/unit/ridley_spec.rb
@@ -25,6 +25,7 @@ describe Ridley do
           chef_server_url          "https://api.opscode.com"
           cache_options(:path => "~/.chef/checksums")
           syntax_check_cache_path  "/foo/bar"
+          ssl_verify_mode          :verify_none
         )
       end
 
@@ -45,6 +46,7 @@ describe Ridley do
           server_url: 'https://api.opscode.com',
           syntax_check_cache_path: "/foo/bar",
           cache_options: { path: "~/.chef/checksums" },
+          ssl: {verify: false},
         )).and_return(nil)
 
         subject.from_chef_config(path)
@@ -59,6 +61,7 @@ describe Ridley do
           server_url: 'https://api.opscode.com',
           syntax_check_cache_path: "/foo/bar",
           cache_options: { path: "~/.chef/checksums" },
+          ssl: {verify: false},
         ))
 
         subject.from_chef_config(path, client_key: 'bacon.pem', client_name: 'bacon')


### PR DESCRIPTION
Hi.

`knife.rb` has a `ssl_verify_mode` option.
https://docs.chef.io/config_rb_knife.html

Use this option in `from_chef_config` method.

if `ssl_verify_mode` is `verify_none`, ridley adds `ssl: {verify: false}` into config.
