### PR TITLE
try avoiding development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   - apt
   - bundler
 dist: precise
-
+bundler_args: --without development
 script: "bundle exec thor spec:$TEST_SUITE"
 before_install:
   - gem update --system


### PR DESCRIPTION
We're seeing travis failures caused by guard's dependencies.
Signed-off-by: Thom May <thom@may.lt>