### PR TITLE
Fixes node.all missing names

### DIFF
--- a/lib/ridley/resource.rb
+++ b/lib/ridley/resource.rb
@@ -64,7 +64,7 @@ module Ridley
     # @return [Array<Object>]
     def all
       request(:get, self.class.resource_path).collect do |identity, location|
-        new(self.class.representation.chef_id => identity)
+        new(self.class.representation.chef_id.to_s => identity)
       end
     end
 


### PR DESCRIPTION
With version 4.5.1, ridley Resource.all silently fails to set the resource chef_id/name since the representation.chef_id field returns a symbol and [dotted-paths#dig](https://github.com/reset/buff-extensions/blob/master/lib/buff/extensions/hash/dotted_paths.rb#L90) expects a string.

expected
```
ridley.node.all.map{|n| n.name}
=> ["node1.testdomain",
"node2.testdomain",
"node3.testdomain",
"node4.testdomain",
 ...
```
actual
```
ridley.node.all.map{|n| n.name}
=> [nil,
 nil,
 nil,
 nil,
 ...
```
Converting `to_s` gets the expected result for nodes, roles, and data bags. I also checked cookbook.all but that appears to be a separate code path.