### PR TITLE
Use httpclient instead of net_http since it respects no_proxy.

### DIFF
--- a/lib/ridley/sandbox_uploader.rb
+++ b/lib/ridley/sandbox_uploader.rb
@@ -74,7 +74,7 @@ module Ridley
         'Content-Type' => 'application/x-binary',
         'content-md5' => calculated_checksum
       }
-
+      
       url         = URI(checksum[:url])
       upload_path = url.path
       url.path    = ""
@@ -92,7 +92,7 @@ module Ridley
           c.response :chef_response
           c.response :follow_redirects
           c.request :chef_auth, self.client_name, self.client_key
-          c.adapter :net_http
+          c.adapter :httpclient
         end.put(upload_path, io.read, headers)
       rescue Ridley::Errors::HTTPError => ex
         abort(ex)


### PR DESCRIPTION
Fixes #153 

Berkshelf 3.3.0 added support for the no_proxy env var, only for downloads from the public Supermarket.
See: https://github.com/berkshelf/berkshelf/pull/1393/files

This PR is an extension of that work to support no_proxy for all requests with Ridley.

