### PR TITLE
Lock buff-ignore version to 1.1.x

### DIFF
--- a/ridley.gemspec
+++ b/ridley.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'varia_model',             '~> 0.4.0'
   s.add_dependency 'buff-config',             '~> 1.0'
   s.add_dependency 'buff-extensions',         '~> 1.0'
-  s.add_dependency 'buff-ignore',             '~> 1.1'
+  s.add_dependency 'buff-ignore',             '~> 1.1.1'
   s.add_dependency 'buff-shell_out',          '~> 0.1'
   s.add_dependency 'celluloid',               '~> 0.16.0'
   s.add_dependency 'celluloid-io',            '~> 0.16.1'


### PR DESCRIPTION
Yesterday buff-ignore got released 1.2.0, which requires Ruby 2.1.x. And Ridley takes it into setups were this is not affordable, like AWS OpsWorks with Chef 11.10. This fix should relieve the problem a little bit while updating tasks complete.