### PR TITLE
relax gem pin on faraday

### DIFF
--- a/ridley.gemspec
+++ b/ridley.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid-io',            '~> 0.16.1'
   s.add_dependency 'chef-config',             '>= 12.5.0'
   s.add_dependency 'erubis'
-  s.add_dependency 'faraday',                 '~> 0.9.0'
+  s.add_dependency 'faraday',                 '~> 0.9'
   s.add_dependency 'hashie',                  '>= 2.0.2', '< 4.0.0'
   s.add_dependency 'httpclient',              '~> 2.7'
   s.add_dependency 'json',                    '>= 1.7.7'


### PR DESCRIPTION
should eliminate the Fixnum warning spam on 2.4.0 and probably head off other problems.