### PR TITLE
In one of the use case where name attribute of metadata starts with u…

### DIFF
--- a/lib/ridley/chef/cookbook/metadata.rb
+++ b/lib/ridley/chef/cookbook/metadata.rb
@@ -245,6 +245,7 @@ module Ridley::Chef
       # === Returns
       # name<String>:: Returns the current cookbook name.
       def name(arg = nil)
+        arg = arg.nil? nil : arg.downcase
         set_or_return(
           :name,
           arg,


### PR DESCRIPTION
In one of the use case where name attribute of metadata starts with uppercase which resulted in not able to resolve cookbook by name.  This will override this attribute to be lowercase without modifying existing metadata file.

The cookbooks in question are https://github.com/oneops/circuit-oneops-1.git.

